### PR TITLE
Fix for getMessageData function

### DIFF
--- a/classes/EmailReader.php
+++ b/classes/EmailReader.php
@@ -328,6 +328,11 @@ class EmailReader
                     }
                 }
 
+                // Clear email message and attachments from email class object, to be empty for when next message is read
+                $this->plainMessage = null;
+                $this->htmlMessage = null;
+                $this->attachments = null;
+
                 return $emailMessage;
 
             } else {


### PR DESCRIPTION
Fix for getMessageData function, to clear data from previous messages, to avoid new message showing up with previous message's data